### PR TITLE
meson.build: fix 0.5.1 -> 0.5.2 release version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libtypec','c',
 license: 'MIT',
-version: '0.5.1',
+version: '0.5.2',
 default_options : [
 	'warning_level=0'])
 


### PR DESCRIPTION
0.5.2 was released, however only the version in
CMakeLists was bumped. Bump the version in meson
as well.