### PR TITLE
meson.build: fix soversion 5 -> 0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ library('typec',
 	'libtypec_sysfs_ops.c',
 	'libtypec_dbgfs_ops.c',
 	version : meson.project_version(),
-	soversion : '5',
+	soversion : '0',
 	dependencies: libudev_dep,
 	install: true,
 )


### PR DESCRIPTION
Hello

This is another fix which got one of the Gentoo maintainers really worked up in the original PR

https://github.com/gentoo/gentoo/pull/36736

I'll retry adding to Gentoo once we fix this, thanks!