### PR TITLE
libtypec: Fix BCD parsing of version from sysfs

### DIFF
--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -175,7 +175,7 @@ static short get_bcd_from_rev_file(char *path)
 		        fclose(fp);
 			return -1;
                 }
-		bcd = ((buf[0] - '0') << 8) | (buf[2] - '0');
+		bcd = ((buf[0] - '0') << 8) | ((buf[2] - '0') << 4);
 
 		fclose(fp);
 	}


### PR DESCRIPTION
Fixing BCD parsing of version numbers from sysfs. With this fix, verbose information of PDOs is being displayed for 'lstypec -v'

Before the fix
libtypec# ./utils/lstypec -v
.......
.......
Connector 0 Capability/Status
  Operation Modes Supported: 0x04 (DRP(Rp/Rd))
  Connector PDO Data (Source):
    PDO1: 0x3e019096
  Connector PDO Data (Sink):
    PDO1: 0x2f019096
    PDO2: 0x5a419096

After the fix 
/libtypec# ./utils/lstypec -v
....
.....
Connector 0 Capability/Status
  Operation Modes Supported: 0x04 (DRP(Rp/Rd))
  Connector PDO Data (Source):
    PDO1: 0x3e019096
      Maximum Current in 10mA units: 150
      Voltage in 50mV units:         100
      Peak Current:                    0
      EPR Mode Capable:                0
      Dual-Role Data:                  1
      USB Communications Capable:      1
      Unconstrained Power:             1
      USB Suspend Supported:           1
      Daul-Role Power:                 1
      Fixed supply:                    0
  Connector PDO Data (Sink):
    PDO1: 0x2f019096
      Maximum Current in 10mA units: 150
      Voltage in 50mV units:         100
      Peak Current:                    0
      EPR Mode Capable:                0
      Dual-Role Data:                  1
      USB Communications Capable:      1
      Unconstrained Power:             1
      USB Suspend Supported:           0
      Daul-Role Power:                 1
      Fixed supply:                    0
    PDO2: 0x5a419096
      Maximum Allowable Power in 250mW units: 150
      Minimum Voltage in 50mV units: 100
      Maximum Voltage in 50mV units: 420
      Battery:                         1