### PR TITLE
libtypec: Init Fixed supply PDO structures

### DIFF
--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -407,6 +407,9 @@ static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 	
 	unsigned int tmp;
 
+	memset(&fxd_src, 0, sizeof(fxd_src));
+	memset(&fxd_snk, 0, sizeof(fxd_snk));
+
 	if(src_snk)
 	{
 		fxd_src.obj_fixed_sply.type = 0;

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -175,7 +175,7 @@ static short get_bcd_from_rev_file(char *path)
 		        fclose(fp);
 			return -1;
                 }
-		bcd = ((buf[0] - '0') << 8) | (buf[2] - '0');
+		bcd = ((buf[0] - '0') << 8) | ((buf[2] - '0') << 4);
 
 		fclose(fp);
 	}


### PR DESCRIPTION
Without initializing fixed supply PDO structures to 0, seeing an intermittent different value for source PDO. This is because at times bit 22 is being set, which is Reserved field and should always be 0

 Connector PDO Data (Source): 
    PDO1: 0x3e019096 ----> Correct value
    
Connector PDO Data (Source):
    PDO1: 0x3e419096 -----> Intermittently seeing this value with reserved field being set

With the above init, no more seeing the above intermittent value.