### PR TITLE
libtypec: Fix num alt modes for sysfs

### DIFF
--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -580,7 +580,7 @@ static int libtypec_sysfs_get_capability_ops(struct libtypec_capability_data *ca
 {
 	DIR *typec_path = opendir(SYSFS_TYPEC_PATH), *port_path;
 	struct dirent *typec_entry, *port_entry;
-	int num_ports = 0, num_alt_mode = 0;
+	int num_ports = 0, num_alt_mode = 0, num_port_alt = 0;
 	char path_str[512], port_content[512 + 64];
 
 	if (!typec_path)
@@ -600,15 +600,19 @@ static int libtypec_sysfs_get_capability_ops(struct libtypec_capability_data *ca
 
 			/*Scan the port capability*/
 			port_path = opendir(path_str);
+			num_port_alt = 0;
 
 			while ((port_entry = readdir(port_path)))
 			{
 
 				if (!(strncmp(port_entry->d_name, "port", 4)) && (strlen(port_entry->d_name) <= MAX_PORT_MODE_STR))
 				{
-					num_alt_mode++;
+					num_port_alt++;
 				}
 			}
+			/*Counting different alt modes supported by the PPM*/
+			if(num_alt_mode < num_port_alt)
+				num_alt_mode = num_port_alt;
 
 			snprintf(port_content, sizeof(port_content), "%s/%s", path_str, "usb_power_delivery_revision");
 

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -407,6 +407,9 @@ static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 	
 	unsigned int tmp;
 
+	memset(&fxd_src, 0, sizeof(fxd_src));
+	memset(&fxd_snk, 0, sizeof(fxd_snk));
+
 	if(src_snk)
 	{
 		fxd_src.obj_fixed_sply.type = 0;

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -175,7 +175,7 @@ static short get_bcd_from_rev_file(char *path)
 		        fclose(fp);
 			return -1;
                 }
-		bcd = ((buf[0] - '0') << 8) | (buf[2] - '0');
+		bcd = ((buf[0] - '0') << 8) | ((buf[2] - '0') << 4);
 
 		fclose(fp);
 	}


### PR DESCRIPTION
For sysfs interface, we are counting alternate modes of each port and displaying that as the number of alternate modes supported by the PPM. Fixing that to not duplicate number of alternate modes.

Without the fix:
libtypec# ./utils/lstypec
.....
USB-C Platform Policy Manager Capability
  Number of Connectors: 4
  Number of Alternate Modes: 7
  USB Power Delivery Revision: 3.1
  USB Type-C Revision:  2.2
  USB BC Revision: 0.0

With the fix:
libtypec# ./utils/lstypec 
.....
USB-C Platform Policy Manager Capability
  Number of Connectors: 4
  Number of Alternate Modes: 2
  USB Power Delivery Revision: 3.10
  USB Type-C Revision:  2.20
  USB BC Revision: 0.0