### PR TITLE
libtypec: Fix minor issues related to PDO data

### DIFF
--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -580,7 +580,7 @@ static int libtypec_sysfs_get_capability_ops(struct libtypec_capability_data *ca
 {
 	DIR *typec_path = opendir(SYSFS_TYPEC_PATH), *port_path;
 	struct dirent *typec_entry, *port_entry;
-	int num_ports = 0, num_alt_mode = 0;
+	int num_ports = 0, num_alt_mode = 0, num_port_alt = 0;
 	char path_str[512], port_content[512 + 64];
 
 	if (!typec_path)
@@ -600,15 +600,19 @@ static int libtypec_sysfs_get_capability_ops(struct libtypec_capability_data *ca
 
 			/*Scan the port capability*/
 			port_path = opendir(path_str);
+			num_port_alt = 0;
 
 			while ((port_entry = readdir(port_path)))
 			{
 
 				if (!(strncmp(port_entry->d_name, "port", 4)) && (strlen(port_entry->d_name) <= MAX_PORT_MODE_STR))
 				{
-					num_alt_mode++;
+					num_port_alt++;
 				}
 			}
+			/*Counting different alt modes supported by the PPM*/
+			if(num_alt_mode < num_port_alt)
+				num_alt_mode = num_port_alt;
 
 			snprintf(port_content, sizeof(port_content), "%s/%s", path_str, "usb_power_delivery_revision");
 

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -407,6 +407,9 @@ static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 	
 	unsigned int tmp;
 
+	memset(&fxd_src, 0, sizeof(fxd_src));
+	memset(&fxd_snk, 0, sizeof(fxd_snk));
+
 	if(src_snk)
 	{
 		fxd_src.obj_fixed_sply.type = 0;

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -312,7 +312,7 @@ static unsigned int get_variable_supply_pdo(char *path, int src_snk)
 	union libtypec_variable_supply_src var_src;
 	unsigned int tmp;
 
-	var_src.obj_var_sply.type = 1;
+	var_src.obj_var_sply.type = PDO_VARIABLE;
 	
 	snprintf(port_content, sizeof(port_content), "%s/%s", path, "maximum_voltage");
 	tmp = get_dword_from_path(port_content);
@@ -421,7 +421,7 @@ static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 		fxd_src.obj_fixed_sply.usb_suspend = get_dword_from_path(port_content);
 		
 		snprintf(port_content, sizeof(port_content), "%s/%s", path, "unconstrained_power");
-		fxd_src.obj_fixed_sply.uncons_pwr = get_dword_from_path(path);
+		fxd_src.obj_fixed_sply.uncons_pwr = get_dword_from_path(port_content);
 		
 		snprintf(port_content, sizeof(port_content), "%s/%s", path, "usb_communication_capable");
 		fxd_src.obj_fixed_sply.usb_comm = get_dword_from_path(port_content);
@@ -452,9 +452,12 @@ static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 		
 		snprintf(port_content, sizeof(port_content), "%s/%s", path, "dual_role_power");
 		fxd_snk.obj_fixed_supply.drp = get_dword_from_path(port_content);
+
+		snprintf(port_content, sizeof(port_content), "%s/%s", path, "higher_capability");
+		fxd_snk.obj_fixed_supply.higher_caps = get_dword_from_path(port_content);
 		
 		snprintf(port_content, sizeof(port_content), "%s/%s", path, "unconstrained_power");
-		fxd_snk.obj_fixed_supply.uncons_pwr = get_dword_from_path(path);
+		fxd_snk.obj_fixed_supply.uncons_pwr = get_dword_from_path(port_content);
 		
 		snprintf(port_content, sizeof(port_content), "%s/%s", path, "usb_communication_capable");
 		fxd_snk.obj_fixed_supply.usb_comm_cap = get_dword_from_path(port_content);

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -175,7 +175,7 @@ static short get_bcd_from_rev_file(char *path)
 		        fclose(fp);
 			return -1;
                 }
-		bcd = ((buf[0] - '0') << 8) | (buf[2] - '0');
+		bcd = ((buf[0] - '0') << 8) | ((buf[2] - '0') << 4);
 
 		fclose(fp);
 	}

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -842,7 +842,7 @@ void print_capabilities_port(int i)
     ret = libtypec_get_pdos(i, 0, 0, &num_pdos, 0, 0, pdo_data);
     if (ret > 0) {
       printf("  Connector PDO Data (Sink):\n");
-      print_source_pdo_data(pdo_data, num_pdos, get_cap_data.bcdPDVersion);
+      print_sink_pdo_data(pdo_data, num_pdos, get_cap_data.bcdPDVersion);
     }
     else
         printf("  Connector PDO Data (Source) returned : %d\n", ret);


### PR DESCRIPTION
This fix resolves the below issues:
1. For sysfs interface, Variable type PDO(2) is being saved as Battery type PDO(1).
2. For sysfs interface, unconstrained power field is not properly being read for Fixed types PDOs.
3. For sysfs interface, higher capability field is missing from Sink fixed type PDO data.
4. Mistakenly using Source PDO print function to display Sink PDO data too for the connectors.