### PR TITLE
Reset soversion to 0 when building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set_target_properties(libtypec PROPERTIES
 	OUTPUT_NAME "typec"
 	VERSION ${PROJECT_VERSION}
-	SOVERSION ${PROJECT_VERSION_MINOR}
+	SOVERSION "0"
 	PUBLIC_HEADER "libtypec.h;${CMAKE_CURRENT_BINARY_DIR}/libtypec_config.h")
 
 add_subdirectory(utils)


### PR DESCRIPTION
Unlike in meson.build, the version number was incorrectly used as soversion.