### PR TITLE
Build fixes

### DIFF
--- a/libtypec.c
+++ b/libtypec.c
@@ -46,7 +46,6 @@ static char ver_buf[64];
 static struct utsname ker_uname;
 static const struct libtypec_os_backend *cur_libtypec_os_backend;
 
-
 /**
  * \mainpage libtypec 0.4.0 API Reference
  *
@@ -143,7 +142,6 @@ char *get_os_name(void)
 int libtypec_init(char **session_info, enum libtypec_backend backend)
 {
     int ret;
-    struct statfs sb;
 
     sprintf(ver_buf, "libtypec %d.%d.%d", LIBTYPEC_MAJOR_VERSION, LIBTYPEC_MINOR_VERSION,LIBTYPEC_PATCH_VERSION);
 
@@ -190,7 +188,6 @@ int libtypec_init(char **session_info, enum libtypec_backend backend)
  *
  * \returns 0 on success
  */
-
 int libtypec_exit(void)
 {
     if (!cur_libtypec_os_backend || !cur_libtypec_os_backend->exit )
@@ -246,6 +243,7 @@ int libtypec_set_pdr(unsigned char conn_num, unsigned char pdr)
 
     return cur_libtypec_os_backend->set_pdr_ops(conn_num, pdr);
 }
+
 /**
  * This function shall be used to set the CC operation mode
  *
@@ -260,7 +258,6 @@ int libtypec_set_ccom(unsigned char conn_num, unsigned char ccom)
 
     return cur_libtypec_os_backend->set_ccom_ops(conn_num, ccom);
 }
-
 
 /**
  * This function shall be used to get the platform policy capabilities
@@ -312,6 +309,7 @@ int libtypec_get_alternate_modes(int recipient, int conn_num, struct altmode_dat
 
     return cur_libtypec_os_backend->get_alternate_modes(recipient, conn_num, alt_mode_data);
 }
+
 /**
  * This function shall be used to get the Cable Property of a connector
  *
@@ -406,6 +404,7 @@ int libtypec_get_pdos (int conn_num, int partner, int offset, int *num_pdo, int 
     return cur_libtypec_os_backend->get_pdos_ops(conn_num,  partner, offset,  num_pdo,  src_snk, type, pdo_data);
 
 }
+
 /**
  * This function shall be used to error status info in the system
  *
@@ -422,6 +421,7 @@ int libtypec_get_error_status(unsigned char conn_num, struct libtypec_get_error_
     return cur_libtypec_os_backend->get_error_status_ops(conn_num, error_status);
 
 }
+
 /**
  * This function shall be used to set new alternate mode in the system
  *
@@ -438,6 +438,7 @@ int libtypec_set_new_cam(unsigned char conn_num, unsigned char entry_exit, unsig
     return cur_libtypec_os_backend->set_new_cam_ops(conn_num, entry_exit, new_cam, am_spec);
 
 }
+
 /**
  * This function shall be used to current alt mode configuration status
  *
@@ -453,6 +454,7 @@ int libtypec_get_cam_cs(unsigned char conn_num, unsigned char cam, struct libtyp
 
     return cur_libtypec_os_backend->get_cam_cs_ops(conn_num, cam, cam_cs);
 }
+
 /**
  * This function shall be used to retrive number of retrive the llpm ppm info in the system
  *
@@ -507,6 +509,7 @@ int libtypec_get_bb_data(int bb_instance,char* bb_data)
     return cur_libtypec_os_backend->get_bb_data(bb_instance,bb_data);
 
 }
+
 int libtypec_register_typec_notification_callback(enum usb_typec_event event, usb_typec_callback_t cb, void* data)
 {
     if (event >= USBC_EVENT_COUNT) {
@@ -522,7 +525,10 @@ int libtypec_register_typec_notification_callback(enum usb_typec_event event, us
     node->data = data;
     node->next = registered_callbacks[event];
     registered_callbacks[event] = node;
+
+    return 0;
 }
+
 int libtypec_unregister_callback(enum usb_typec_event event, usb_typec_callback_t cb) {
     if (event >= USBC_EVENT_COUNT) {
         fprintf(stderr, "Invalid event\n");
@@ -538,6 +544,8 @@ int libtypec_unregister_callback(enum usb_typec_event event, usb_typec_callback_
             node = &(*node)->next;
         }
     }
+
+    return 0;
 }
 
 void libtypec_monitor_events(void)

--- a/libtypec_dbgfs_ops.c
+++ b/libtypec_dbgfs_ops.c
@@ -285,7 +285,7 @@ static int libtypec_dbgfs_get_alternate_modes(int recipient, int conn_num, struc
 				alt_mode_data[i].svid 	 = buf[1] << 8 | buf[0];
 				alt_mode_data[i].vdo 	 = buf[5] << 24 | buf[4] << 16 | buf[3] << 8 | buf[2];
 
-				if(alt_mode_data[i].svid == 0 | alt_mode_data[i].svid == psvid)
+				if((alt_mode_data[i].svid == 0) | (alt_mode_data[i].svid == psvid))
 					break;
 				psvid = alt_mode_data[i].svid;
 			}
@@ -357,7 +357,7 @@ static int libtypec_dbgfs_get_pdos_ops(int conn_num, int partner, int offset, in
 				if(ret< 16)
 					return -1;
 				pdo_data->pdo[i] = buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0];
-				if(pdo_data->pdo[i] == 0 | pdo_data->pdo[i] == ppdo)
+				if((pdo_data->pdo[i] == 0) | (pdo_data->pdo[i] == ppdo))
 					break;
 				ppdo = pdo_data->pdo[i];
 			}

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -869,7 +869,7 @@ static int libtypec_sysfs_get_connector_status_ops(int conn_num, struct libtypec
 
 			max_mw = (cur * volt) / (250 * 1000);
 
-			conn_sts->RequestDataObject = ((op_mw << 10)) | (max_mw)&0x3FF;
+			conn_sts->RequestDataObject = ((op_mw << 10)) | ((max_mw)&0x3FF);
 		}
 	}
 	return 0;

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -308,7 +308,7 @@ static int get_cable_mode_support(char *path)
 }
 static unsigned int get_variable_supply_pdo(char *path, int src_snk)
 {
-	char path_str[512], port_content[1024];
+	char port_content[1024];
 	union libtypec_variable_supply_src var_src;
 	unsigned int tmp;
 
@@ -339,7 +339,7 @@ static unsigned int get_variable_supply_pdo(char *path, int src_snk)
 }
 static unsigned int get_battery_supply_pdo(char *path, int src_snk)
 {
-	char path_str[512], port_content[512 + 512];
+	char port_content[512 + 512];
 	union libtypec_battery_supply_src bat_src;
 	unsigned int tmp;
 
@@ -372,7 +372,7 @@ static unsigned int get_battery_supply_pdo(char *path, int src_snk)
 }
 static unsigned int get_programmable_supply_pdo(char *path, int src_snk)
 {
-	char path_str[512], port_content[512 + 512];
+	char port_content[512 + 512];
 	union libtypec_pps_src pps_src={0};
 	unsigned int tmp;
 
@@ -401,7 +401,7 @@ static unsigned int get_programmable_supply_pdo(char *path, int src_snk)
 }
 static unsigned int get_fixed_supply_pdo(char *path, int src_snk)
 {
-	char path_str[512], port_content[512 + 512];
+	char port_content[512 + 512];
 	union libtypec_fixed_supply_src fxd_src;
 	union libtypec_fixed_supply_snk fxd_snk;
 	
@@ -641,7 +641,6 @@ static int libtypec_sysfs_get_capability_ops(struct libtypec_capability_data *ca
 static int libtypec_sysfs_get_conn_capability_ops(int conn_num, struct libtypec_connector_cap_data *conn_cap_data)
 {
 	struct stat sb;
-	struct dirent *port_entry;
 	char path_str[512], port_content[512 + 64];
 
 	snprintf(path_str, sizeof(path_str), SYSFS_TYPEC_PATH "/port%d", conn_num);
@@ -788,7 +787,6 @@ static int libtypec_sysfs_get_alternate_modes(int recipient, int conn_num, struc
 static int libtypec_sysfs_get_cable_properties_ops(int conn_num, struct libtypec_cable_property *cbl_prop_data)
 {
 	struct stat sb;
-	struct dirent *port_entry;
 	char path_str[512], port_content[512 + 64];
 
 	snprintf(path_str, sizeof(path_str), SYSFS_TYPEC_PATH "/port%d-cable", conn_num);
@@ -819,7 +817,6 @@ static int libtypec_sysfs_get_cable_properties_ops(int conn_num, struct libtypec
 static int libtypec_sysfs_get_connector_status_ops(int conn_num, struct libtypec_connector_status *conn_sts)
 {
 	struct stat sb;
-	struct dirent *port_entry;
 	char path_str[512], port_content[512 + 64];
 	int ret;
 
@@ -993,8 +990,8 @@ static int libtypec_sysfs_get_pdos_ops(int conn_num, int partner, int offset, in
 {
 	int num_pdos_read = 0;
 	char path_str[512], port_content[512 + 256];
-	DIR *typec_path , *port_path;
-	struct dirent *typec_entry, *port_entry;
+	DIR *typec_path;
+	struct dirent *typec_entry;
 
 	snprintf(path_str, sizeof(path_str), SYSFS_TYPEC_PATH "/port%d", conn_num);
 

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -1079,7 +1079,8 @@ static int libtypec_sysfs_get_bb_status(unsigned int *num_bb_instance)
 
 static int libtypec_sysfs_get_bb_data(int num_billboards,char* bb_data)
 {
-	int ret = 0, count;
+	int ret = 0;
+	unsigned int count;
 
 	ret =  libtypec_sysfs_get_bb_status(&count);
 

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -73,8 +73,6 @@ void print_usage() {
 }
 
 void parse_args(int argc, char *argv[]) {
-    int opt;
-
     // Initialize the CmdArgs structure with default values
     lstypec_args.verbose = 0;
     lstypec_args.help = 0;
@@ -414,9 +412,6 @@ void print_alternate_mode_data(int recipient, uint32_t id_header, int num_modes,
 
 void print_identity_data(int recipient, union libtypec_discovered_identity id, struct libtypec_connector_cap_data conn_data)
 {
-  union id_header id_hdr_val;
-  id_hdr_val.id_hdr = id.disc_id.id_header;
-
   if (recipient == AM_SOP)
   {
     printf("  Partner Identity :\n");
@@ -762,7 +757,7 @@ void lstypec_print(char *val, int type)
 }
 void print_capabilities_partner(int i)
 {
-    int ret, opt, num_modes, num_pdos;
+    int ret, num_modes, num_pdos;
 
    // Partner
     num_modes = libtypec_get_alternate_modes(AM_SOP, i, am_data);
@@ -791,7 +786,7 @@ void print_capabilities_partner(int i)
 }
 void print_capabilities_cable(int i)
 {
-    int ret, opt, num_modes, num_pdos;
+    int ret, num_modes;
 
      // Resetting port properties
     cable_prop.cable_type = CABLE_TYPE_PASSIVE;
@@ -815,7 +810,7 @@ void print_capabilities_cable(int i)
 }
 void print_capabilities_port(int i)
 {
-    int ret, opt, num_modes, num_pdos;
+    int ret, num_modes, num_pdos;
 
     // Connector Capabilities
 	printf("\nConnector %d Capability/Status\n", i);

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -244,21 +244,21 @@ void print_vdo(uint32_t vdo, int num_fields, const struct vdo_field vdo_fields[]
     if (!vdo_fields[i].print)
       continue;
 
-      uint32_t field = (vdo >> vdo_fields[i].index) & vdo_fields[i].mask;
-      printf("      %s: %*d", vdo_fields[i].name, FIELD_WIDTH(MAX_FIELD_LENGTH - ((int) strlen(vdo_fields[i].name))), ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask));
-      if (vdo_field_desc[i][0] != NULL) {
-        // decode field
-        printf(" (%s)\n", vdo_field_desc[i][field]);
-      } else if (strcmp(vdo_fields[i].name, "USB Vendor ID")  == 0) {
-        // decode vendor id
-         char vendor_str[128];
-         uint16_t svid = ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask);
-         get_vendor_string(vendor_str, sizeof(vendor_str), svid);
-        printf(" (%s)\n", (vendor_str[0] == '\0' ? "unknown" : vendor_str));
-      } else {
-        // No decoding
-        printf("\n");
-      }
+    uint32_t field = (vdo >> vdo_fields[i].index) & vdo_fields[i].mask;
+    printf("      %s: %*d", vdo_fields[i].name, FIELD_WIDTH(MAX_FIELD_LENGTH - ((int) strlen(vdo_fields[i].name))), ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask));
+    if (vdo_field_desc[i][0] != NULL) {
+      // decode field
+      printf(" (%s)\n", vdo_field_desc[i][field]);
+    } else if (strcmp(vdo_fields[i].name, "USB Vendor ID")  == 0) {
+      // decode vendor id
+       char vendor_str[128];
+       uint16_t svid = ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask);
+       get_vendor_string(vendor_str, sizeof(vendor_str), svid);
+      printf(" (%s)\n", (vendor_str[0] == '\0' ? "unknown" : vendor_str));
+    } else {
+      // No decoding
+      printf("\n");
+    }
   }
 }
 

--- a/utils/typecstatus.c
+++ b/utils/typecstatus.c
@@ -109,8 +109,9 @@ static unsigned long get_dword_from_path(char *path)
 
 int typec_status_billboard()
 {
-        int ret,index=0;;
-        unsigned char bb_data[512];
+        int ret;
+        unsigned int index=0;
+        char bb_data[512];
 
         ret = libtypec_get_bb_status(&index);
 
@@ -162,7 +163,7 @@ int typec_status_billboard()
 
                         idx =  idx < bmCONF_STR_ARR_MAX ? idx : bmCONF_STR_ARR_MAX;
 
-                        char *aum = &bb_bos_desc->cap_desc_aum_array_start;
+                        unsigned char *aum = &bb_bos_desc->cap_desc_aum_array_start;
 
                         aum = aum + (x*4);
 

--- a/utils/usbcview.c
+++ b/utils/usbcview.c
@@ -11,7 +11,7 @@ GtkTreeStore *create_tree_store() {
   int ret;
   GtkTreeStore *store = gtk_tree_store_new(1, G_TYPE_STRING);
 
-  GtkTreeIter parent, child, grandchild;
+  GtkTreeIter parent, child;
 
   names_init();
 
@@ -232,7 +232,7 @@ void build_cable_prop(struct libtypec_cable_property cable_prop, int conn_num)
 
 void build_capabilities_partner(int i)
 {
-    int ret, opt, num_modes, num_pdos;
+    int num_modes;
 
    // Partner
     num_modes = libtypec_get_alternate_modes(AM_SOP, i, am_data);
@@ -241,7 +241,7 @@ void build_capabilities_partner(int i)
 }
 void build_capabilities_cable(int i)
 {
-    int ret, opt, num_modes, num_pdos;
+    int ret, num_modes;
 
      // Resetting port properties
     cable_prop.cable_type = CABLE_TYPE_PASSIVE;
@@ -260,7 +260,7 @@ void build_capabilities_cable(int i)
 
 void build_capabilities_port(int i)
 {
-  int ret, opt, num_modes, num_pdos;
+  int num_modes;
   char val[512];
 
 
@@ -312,9 +312,8 @@ void on_tree_selection_changed(GtkTreeSelection *selection, gpointer data) {
   GtkTreeIter iter;
   GtkTreeModel *model;
   gchar *text;
-  char string_data[1024];
-	GtkTextIter begin;
-	GtkTextIter end;
+  GtkTextIter begin;
+  GtkTextIter end;
   int num;
 
   gtk_text_buffer_get_start_iter(txt_buffer,&begin);
@@ -323,8 +322,6 @@ void on_tree_selection_changed(GtkTreeSelection *selection, gpointer data) {
 
   if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
     gtk_tree_model_get(model, &iter, 0, &text, -1);
-
-    GtkTextBuffer *buffer = (GtkTextBuffer *)data;
 
     if (strstr(text, "Port") != NULL) {
       char *p = strchr(text,' ');
@@ -357,8 +354,6 @@ void show_error_dialog(const gchar *message) {
 }
 
 int main(int argc, char *argv[]) {
-  int ret;
-
   gtk_init(&argc, &argv);
 
 

--- a/utils/usbcview.c
+++ b/utils/usbcview.c
@@ -56,29 +56,29 @@ void build_vdo(uint32_t vdo, int num_fields, const struct vdo_field vdo_fields[]
     if (!vdo_fields[i].print)
       continue;
 
-      uint32_t field = (vdo >> vdo_fields[i].index) & vdo_fields[i].mask;
-      sprintf(val,"      %s: %*d", vdo_fields[i].name, FIELD_WIDTH(MAX_FIELD_LENGTH - ((int) strlen(vdo_fields[i].name))), ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask));
+    uint32_t field = (vdo >> vdo_fields[i].index) & vdo_fields[i].mask;
+    sprintf(val,"      %s: %*d", vdo_fields[i].name, FIELD_WIDTH(MAX_FIELD_LENGTH - ((int) strlen(vdo_fields[i].name))), ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask));
+    gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
+
+    if (vdo_field_desc[i][0] != NULL) {
+      // decode field
+      sprintf(val," (%s)\n", vdo_field_desc[i][field]);
       gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
 
-      if (vdo_field_desc[i][0] != NULL) {
-        // decode field
-        sprintf(val," (%s)\n", vdo_field_desc[i][field]);
-        gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
+    } else if (strcmp(vdo_fields[i].name, "USB Vendor ID")  == 0) {
+      // decode vendor id
+       char vendor_str[128];
+       uint16_t svid = ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask);
+       get_vendor_string(vendor_str, sizeof(vendor_str), svid);
+      sprintf(val," (%s)\n", (vendor_str[0] == '\0' ? "unknown" : vendor_str));
+      gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
 
-      } else if (strcmp(vdo_fields[i].name, "USB Vendor ID")  == 0) {
-        // decode vendor id
-         char vendor_str[128];
-         uint16_t svid = ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask);
-         get_vendor_string(vendor_str, sizeof(vendor_str), svid);
-        sprintf(val," (%s)\n", (vendor_str[0] == '\0' ? "unknown" : vendor_str));
-        gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
+    } else {
+      // No decoding
+      sprintf(val,"\n");
+      gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
 
-      } else {
-        // No decoding
-        sprintf(val,"\n");
-        gtk_text_buffer_insert_at_cursor(txt_buffer, val,strlen(val));
-
-      }
+    }
   }
 }
 


### PR DESCRIPTION
This cleans up a bunch of build warnings when warning_level=1 is set in meson.build. It doesn't quite  get us quite to being able to turn on all build warnings by default for the build as there's a bunch of -Wpointer-sign in libtypec_dbgfs_ops.c because snprintf expects signed char but is being passed other things, plus a few other bits I haven't looked into that yet but this moves us forward towards that and gets the worst of the problems that cause builds on Fedora to fail.