### PR TITLE
lstypec: Add decoding for PDO voltages and other units

### DIFF
--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -258,8 +258,15 @@ void print_vdo(uint32_t vdo, int num_fields, const struct vdo_field vdo_fields[]
          get_vendor_string(vendor_str, sizeof(vendor_str), svid);
         printf(" (%s)\n", (vendor_str[0] == '\0' ? "unknown" : vendor_str));
       } else {
-        // No decoding
-        printf("\n");
+	int unit_step;
+        char unit_name[4];
+        if (sscanf(vdo_fields[i].name, "%*[^0-9]%d%3s units", &unit_step, unit_name) == 2) {
+          // decode unit
+          printf(" (%d%s)\n", field * unit_step, unit_name);
+        } else {
+          // No decoding
+          printf("\n");
+        }
       }
   }
 }


### PR DESCRIPTION
`lstypec` currently displays PDO fields such as "Voltage in 50mV units" as-is, requiring manual calculations to get useful values out of them.

This patch adds a decoder for such fields, listing a converted value (based on the raw value and the unit step listed in the field name) after the raw value. It's a bit rudimentary, but it works at least for the currently implemented field types.

Previously: Rajaram-Regupathy/libtypec#39